### PR TITLE
Add es6 to env for eslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     ],
     "env": {
       "jest": true,
-      "node": true
+      "node": true,
+      "es6": true
     },
     "rules": {
       "capitalized-comments": "off",


### PR DESCRIPTION
This will get rid of es6 usage errors that are popping up with eslint. 