### PR TITLE
Import pipline_CLI as npm package

### DIFF
--- a/generators/jenkins-overwrites/templates/.jenkins/.pipeline/lib/build.js
+++ b/generators/jenkins-overwrites/templates/.jenkins/.pipeline/lib/build.js
@@ -1,5 +1,5 @@
 'use strict';
-const {OpenShiftClientX} = require('pipeline-cli')
+const {OpenShiftClientX} = require('@bcgov/pipeline-cli')
 const path = require('path');
 
 module.exports = (settings)=>{

--- a/generators/jenkins-overwrites/templates/.jenkins/.pipeline/lib/deploy.js
+++ b/generators/jenkins-overwrites/templates/.jenkins/.pipeline/lib/deploy.js
@@ -1,5 +1,5 @@
 'use strict';
-const {OpenShiftClientX} = require('pipeline-cli')
+const {OpenShiftClientX} = require('@bcgov/pipeline-cli')
 const path = require('path');
 
 module.exports = (settings)=>{

--- a/generators/pipeline/templates/.pipeline/lib/build.js
+++ b/generators/pipeline/templates/.pipeline/lib/build.js
@@ -1,5 +1,5 @@
 'use strict';
-const {OpenShiftClientX} = require('pipeline-cli')
+const {OpenShiftClientX} = require('@bcgov/pipeline-cli')
 const path = require('path');
 
 module.exports = (settings)=>{

--- a/generators/pipeline/templates/.pipeline/lib/clean.js
+++ b/generators/pipeline/templates/.pipeline/lib/clean.js
@@ -1,5 +1,5 @@
 'use strict';
-const {OpenShiftClientX} = require('pipeline-cli')
+const {OpenShiftClientX} = require('@bcgov/pipeline-cli')
 
 module.exports = (settings)=>{
   const phases = settings.phases

--- a/generators/pipeline/templates/.pipeline/lib/config.js
+++ b/generators/pipeline/templates/.pipeline/lib/config.js
@@ -1,5 +1,5 @@
 'use strict';
-const options= require('pipeline-cli').Util.parseArguments()
+const options= require('@bcgov/pipeline-cli').Util.parseArguments()
 const changeId = options.pr //aka pull-request
 const version = '<%= version%>'
 const name = '<%= name%>'

--- a/generators/pipeline/templates/.pipeline/lib/deploy.js
+++ b/generators/pipeline/templates/.pipeline/lib/deploy.js
@@ -1,5 +1,5 @@
 'use strict';
-const {OpenShiftClientX} = require('pipeline-cli')
+const {OpenShiftClientX} = require('@bcgov/pipeline-cli')
 const path = require('path');
 
 module.exports = (settings)=>{

--- a/generators/pipeline/templates/.pipeline/package-lock.json
+++ b/generators/pipeline/templates/.pipeline/package-lock.json
@@ -1,0 +1,89 @@
+{
+  "name": "pipeline",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@bcgov/pipeline-cli": {
+      "version": "1.0.1-0",
+      "resolved": "https://registry.npmjs.org/@bcgov/pipeline-cli/-/pipeline-cli-1.0.1-0.tgz",
+      "integrity": "sha512-DXneptaJuG81Vo+GotZaS4M78uOVnocCCzte6UghOkO+Bt8EQ6xlPblITPXiNDCufO7gOnEmB4T/pyh1ZBnvcw==",
+      "requires": {
+        "debug": "^4.1.0",
+        "lodash.isempty": "^4.0.1",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "snakecase-keys": "^3.1.0"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "map-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
+      "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "snakecase-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-3.1.0.tgz",
+      "integrity": "sha512-QM038drLbhdOY5HcRQVjO1ZJ1WR7yV5D5TIBzcOB/g3f5HURHhfpYEnvOyzXet8K+MQsgeIUA7O7vn90nAX6EA==",
+      "requires": {
+        "map-obj": "^4.0.0",
+        "to-snake-case": "^1.0.0"
+      }
+    },
+    "to-no-case": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/to-no-case/-/to-no-case-1.0.2.tgz",
+      "integrity": "sha1-xyKQcWTvaxeBMsjmmTAhLRtKoWo="
+    },
+    "to-snake-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-snake-case/-/to-snake-case-1.0.0.tgz",
+      "integrity": "sha1-znRpE4l5RgGah+Yu366upMYIq4w=",
+      "requires": {
+        "to-space-case": "^1.0.0"
+      }
+    },
+    "to-space-case": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-space-case/-/to-space-case-1.0.0.tgz",
+      "integrity": "sha1-sFLar7Gysp3HcM6gFj5ewOvJ/Bc=",
+      "requires": {
+        "to-no-case": "^1.0.0"
+      }
+    }
+  }
+}

--- a/generators/pipeline/templates/.pipeline/package.json
+++ b/generators/pipeline/templates/.pipeline/package.json
@@ -18,6 +18,6 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "pipeline-cli": "git+https://github.com/BCDevOps/pipeline-cli.git#v1.1"
+    "@bcgov/pipeline-cli": "^1.0.1-0"
   }
 }

--- a/generators/python-hello/templates/examples/build.js
+++ b/generators/python-hello/templates/examples/build.js
@@ -1,5 +1,5 @@
 "use strict";
-const { OpenShiftClientX } = require("pipeline-cli");
+const { OpenShiftClientX } = require("@bcgov/pipeline-cli");
 const path = require("path");
 
 module.exports = settings => {

--- a/generators/python-hello/templates/examples/config.js
+++ b/generators/python-hello/templates/examples/config.js
@@ -1,5 +1,5 @@
 "use strict";
-const options = require("pipeline-cli").Util.parseArguments();
+const options = require("@bcgov/pipeline-cli").Util.parseArguments();
 const changeId = options.pr; //aka pull-request
 const version = "1";
 const name = "hello";

--- a/generators/python-hello/templates/examples/deploy.js
+++ b/generators/python-hello/templates/examples/deploy.js
@@ -1,5 +1,5 @@
 "use strict";
-const { OpenShiftClientX } = require("pipeline-cli");
+const { OpenShiftClientX } = require("@bcgov/pipeline-cli");
 const path = require("path");
 
 module.exports = settings => {


### PR DESCRIPTION
Instead of import bcgov/pipeline-cli from github, now directly install bcgov/pipeline-cli as npm package.