### PR TITLE
Automatically clean PR deployments on PR close/merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ D:\BCDevOps\bcgov-forks\agri-nmp>git update-index --chmod=+x D:\BCDevOps\bcgov-f
 To deploy Jenkins to your minishift, you can replace `ROUTE_HOST` qualifier from `.pathfinder.gov.bc.ca` to you minishift in `.jenkins\.pipeline\lib\deploy.js`.  
 **Note that GitHub webook won't work for Minishift Jenkins.
 
-# Local Debugging
+## Local Debugging
 Install npm in your .pipeline and you can use the two methods below to debug and directly deploy to Openshift bypassing Jenkins.
 
-## VSCode Debug Mode to test using local code
+### VSCode Debug Mode to test using local code
 Add the below to your launch.json and debug any commands in your .pipeline.
 ```
        {
@@ -219,6 +219,43 @@ cd .pipeline
 npm run build -- --pr=407 --env=build --dev-mode=true
 npm run deploy -- --pr=407 --env=dev
 
+```
+
+## Automatically Clean Up Pull Request Deployments
+The Github Webhook in Jenkins will execute the following clean command when a Pull Request is closed or merged.
+
+```
+npm run clean -- --env=transient --pr={pr-number}
+```
+
+To take advantage of this you can add `transient: true` property to your `phases` objects in `./pipeline/lib/config.js`
+
+For example, the `build` and `dev` keys in the `phases` object below both contain the `transient: true` property.  This will cause the Github Webhook script to automatically run the `clean.js` script on the `build` and `dev` environments when a pull request is closed or merged.
+```javascript
+const phases = {
+  build: {
+    namespace: "tools",
+    name: `${name}`,
+    phase: "build",
+    transient: true  // auto clean build
+  },
+  dev: {
+    namespace: "dev",
+    name: `${name}`,
+    phase: "dev",
+    transient: true  // auto clean dev
+  },
+  test: {
+    namespace: "test",
+    name: `${name}`,
+    phase: "test",
+  },
+  prod: {
+    namespace: "prod",
+    name: `${name}`,
+    phase: "prod",
+  }
+};
 ```
 
 ## License

--- a/generators/jenkins/templates/.jenkins/docker/contrib/jenkins/configuration/scripts.groovy.d/on-gh-event.groovy
+++ b/generators/jenkins/templates/.jenkins/docker/contrib/jenkins/configuration/scripts.groovy.d/on-gh-event.groovy
@@ -58,9 +58,9 @@ static Map exec(List args, File workingDirectory=null, Appendable stdout=null, A
                     println exec(['git', 'fetch', '--no-tags', payload.repository.clone_url, "+${sourceBranch}:PR-${payload.number}"], gitWorkDir)
                     println exec(['git', 'checkout', "PR-${payload.number}"] , gitWorkDir)
 
-                    String npmwPath = gitWorkDir.getAbsolutePath() + '/.pipeline/npmw'
-                    println exec([npmwPath, 'ci'])
-                    println exec([npmwPath, 'run', 'clean' ,'--' ,"--pr=${payload.number}", '--env=transient'])
+                    File pipelineWorkDir = new File("${gitWorkDir.getAbsolutePath()}/.pipeline")
+                    println exec(['./npmw', 'ci'], pipelineWorkDir)
+                    println exec(['./npmw', 'run', 'clean' ,'--' ,"--pr=${payload.number}", '--env=transient'], pipelineWorkDir)
                 }
             }else if ("issue_comment" == ghEventType){
                 def payload = new JsonSlurper().parseText(ghPayload)

--- a/generators/jenkins/templates/.jenkins/docker/contrib/jenkins/configuration/scripts.groovy.d/on-gh-event.groovy
+++ b/generators/jenkins/templates/.jenkins/docker/contrib/jenkins/configuration/scripts.groovy.d/on-gh-event.groovy
@@ -1,0 +1,130 @@
+import groovy.json.*
+
+class OnGhEvent extends Script {
+
+static Map exec(List args, File workingDirectory=null, Appendable stdout=null, Appendable stderr=null, Closure stdin=null){
+    ProcessBuilder builder = new ProcessBuilder(args as String[])
+    if (stderr ==null){
+        builder.redirectErrorStream(true)
+    }
+    if (workingDirectory!=null){
+        builder.directory(workingDirectory)
+    }
+    def proc = builder.start()
+
+    if (stdin!=null) {
+        OutputStream out = proc.getOutputStream();
+        stdin(out)
+        out.flush();
+        out.close();
+    }
+
+    if (stdout == null ){
+        stdout = new StringBuffer()
+    }
+
+    proc.waitForProcessOutput(stdout, stderr)
+    int exitValue= proc.exitValue()
+
+    Map ret = ['out': stdout, 'err': stderr, 'status':exitValue, 'cmd':args]
+
+    return ret
+}
+
+    def run() {
+        String ghPayload = build.buildVariableResolver.resolve("payload")
+        String ghEventType = build.buildVariableResolver.resolve("x_github_event")
+        String buildNumber = build.getNumber()
+        String fullName = build.getProject().getFullName()
+        
+        File workDir = new File("/tmp/jenkins/on-gh-event/${fullName}/${buildNumber}")
+        try{
+            if ("pull_request" == ghEventType){
+                def payload = new JsonSlurper().parseText(ghPayload)
+                if ("closed" == payload.action){
+                    File gitWorkDir = workDir
+                    def ghRepo=com.cloudbees.jenkins.GitHubRepositoryName.create(payload.repository.clone_url).resolveOne()
+                    boolean isFromCollaborator=ghRepo.root.retrieve().asHttpStatusCode(ghRepo.getApiTailUrl("collaborators/${payload.pull_request.user.login}")) == 204
+                    String cloneUrl = payload.repository.clone_url
+                    String sourceBranch = isFromCollaborator?"refs/pull/${payload.number}/head":"refs/heads/${payload.pull_request.base.ref}"
+                    println "Is Collaborator:${isFromCollaborator} (${payload.pull_request.user.login})"
+                    println "Clone Url:${cloneUrl}"
+                    println "Checkout Branch:${sourceBranch}"
+
+                    println exec(['mkdir', '-p', gitWorkDir.getAbsolutePath()])
+                    println exec(['rm', '-rf', gitWorkDir.getAbsolutePath()])
+                    println exec(['git', 'init', gitWorkDir.getAbsolutePath()])
+                    println exec(['git', 'remote', 'add', 'origin', payload.repository.clone_url], gitWorkDir)
+                    println exec(['git', 'fetch', '--no-tags', payload.repository.clone_url, "+${sourceBranch}:PR-${payload.number}"], gitWorkDir)
+                    println exec(['git', 'checkout', "PR-${payload.number}"] , gitWorkDir)
+
+                    String npmwPath = gitWorkDir.getAbsolutePath() + '/.pipeline/npmw'
+                    println exec([npmwPath, 'ci'])
+                    println exec([npmwPath, 'run', 'clean' ,'--' ,"--pr=${payload.number}", '--env=transient'])
+                }
+            }else if ("issue_comment" == ghEventType){
+                def payload = new JsonSlurper().parseText(ghPayload)
+                if ("created" == payload.action && payload.issue.pull_request !=null ){
+                    String comment = payload.comment.body.trim()
+
+                    //OWNER or COLLABORATOR
+                    //https://developer.github.com/v4/enum/commentauthorassociation/
+                    String commentAuthorAssociation = payload.comment.author_association
+                    if (comment.charAt(0) == '/'){
+                        println "command: ${comment}"
+                        String jobName= payload.repository.name
+                        String jobPRName =  payload.repository.full_name
+
+                        List projects = jenkins.model.Jenkins.instance.getAllItems(org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject.class).findAll {
+                            def scmSource=it.getSCMSources()[0]
+                            return payload.repository.owner.login.equalsIgnoreCase(scmSource.getRepoOwner()) && payload.repository.name.equalsIgnoreCase(scmSource.getRepository())
+                        }
+                        List branchProjects = []
+                        projects.each {
+                            def branchProject = it.getItem("PR-${payload.issue.number}")
+                            if (branchProject!=null){
+                                branchProjects.add(branchProject)
+                            }
+                        }
+
+                        if (comment == '/restart' && (commentAuthorAssociation == 'OWNER' || commentAuthorAssociation == 'COLLABORATOR')){
+                            //
+                            branchProjects.each {
+                                def targetProject=it
+                                def cause = new hudson.model.Cause.RemoteCause('github.com', "Pull Request Command By '${payload.comment.user.login}'")
+                                targetProject.scheduleBuild(0, cause)
+                            }
+                        }else if (comment == '/approve' && (commentAuthorAssociation == 'OWNER' || commentAuthorAssociation == 'COLLABORATOR')){
+                            if (branchProjects.size() > 0){
+                                branchProjects.each { targetJob ->
+                                    if (targetJob.getLastBuild()){
+                                        hudson.security.ACL.impersonate(hudson.security.ACL.SYSTEM, {
+                                            for (org.jenkinsci.plugins.workflow.support.steps.input.InputAction inputAction : targetJob.getLastBuild().getActions(org.jenkinsci.plugins.workflow.support.steps.input.InputAction.class)){
+                                                for (org.jenkinsci.plugins.workflow.support.steps.input.InputStepExecution inputStep:inputAction.getExecutions()){
+                                                    if (!inputStep.isSettled()){
+                                                        println inputStep.proceed(null)
+                                                    }
+                                                }
+                                            }
+                                        } as Runnable )
+                                    }
+                                }
+                            }else{
+                                println "There is no project or build associated with ${payload.issue.pull_request.html_url}"
+                            }
+                        }
+                    }
+                }
+            }
+        }finally{
+            exec(['rm', '-rf', workDir.getAbsolutePath()])
+        }
+
+
+        return null;
+    } //end run
+    
+    static void main(String[] args) {
+        org.codehaus.groovy.runtime.InvokerHelper.runScript(OnGhEvent, args)     
+    }
+}

--- a/generators/pipeline/templates/.pipeline/lib/clean.js
+++ b/generators/pipeline/templates/.pipeline/lib/clean.js
@@ -1,74 +1,77 @@
 "use strict";
 const { OpenShiftClientX } = require("@bcgov/pipeline-cli");
 
+const getTargetPhases = (env, phases) => {
+  let target_phase = [];
+  for (const phase in phases) {
+    if (env.match(/^(all|transient)$/) && phases[phase].transient) {
+      target_phase.push(phase);
+    } else if (env === phase) {
+      target_phase.push(phase);
+      break;
+    }
+  }
+
+  return target_phase;
+};
+
 module.exports = settings => {
   const phases = settings.phases;
   const options = settings.options;
   const oc = new OpenShiftClientX(Object.assign({ namespace: phases.build.namespace }, options));
-  const target_phase = options.env;
+  const target_phases = getTargetPhases(options.env, phases);
 
-  for (var k in phases) {
+  target_phases.forEach(k => {
     if (phases.hasOwnProperty(k)) {
       const phase = phases[k];
-      if (k == target_phase) {
-        //console.log(`phase=${phase}`)
-        //oc.raw('get', ['bc'], {selector:`app-name=${phase.name},env-id=${phase.changeId},env-name!=prod,!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`, namespace:phase.namespace, 'output':'custom-columns=kind:.spec.output.to.kind,name:.spec.output.to.name', 'no-headers':'true'})
-        let buildConfigs = oc.get("bc", {
-          selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${
-            oc.git.repository
-          },github-owner=${oc.git.owner}`,
-          namespace: phase.namespace,
-        });
-        buildConfigs.forEach(bc => {
-          if (bc.spec.output.to.kind == "ImageStreamTag") {
-            oc.delete([`ImageStreamTag/${bc.spec.output.to.name}`], {
+
+      let buildConfigs = oc.get("bc", {
+        selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`,
+        namespace: phase.namespace,
+      });
+      buildConfigs.forEach(bc => {
+        if (bc.spec.output.to.kind == "ImageStreamTag") {
+          oc.delete([`ImageStreamTag/${bc.spec.output.to.name}`], {
+            "ignore-not-found": "true",
+            wait: "true",
+            namespace: phase.namespace,
+          });
+        }
+      });
+
+      let deploymentConfigs = oc.get("dc", {
+        selector: `app=${phase.instance},env-id=${phase.changeId},env-name=${k},!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`,
+        namespace: phase.namespace,
+      });
+      deploymentConfigs.forEach(dc => {
+        dc.spec.triggers.forEach(trigger => {
+          if (
+            trigger.type == "ImageChange" &&
+            trigger.imageChangeParams.from.kind == "ImageStreamTag"
+          ) {
+            oc.delete([`ImageStreamTag/${trigger.imageChangeParams.from.name}`], {
               "ignore-not-found": "true",
               wait: "true",
               namespace: phase.namespace,
             });
           }
         });
+      });
 
-        let deploymentConfigs = oc.get("dc", {
-          selector: `app=${phase.instance},env-id=${
-            phase.changeId
-          },env-name=${k},!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`,
-          namespace: phase.namespace,
-        });
-        deploymentConfigs.forEach(dc => {
-          dc.spec.triggers.forEach(trigger => {
-            if (
-              trigger.type == "ImageChange" &&
-              trigger.imageChangeParams.from.kind == "ImageStreamTag"
-            ) {
-              oc.delete([`ImageStreamTag/${trigger.imageChangeParams.from.name}`], {
-                "ignore-not-found": "true",
-                wait: "true",
-                namespace: phase.namespace,
-              });
-            }
-          });
-        });
-
-        oc.raw("delete", ["all"], {
-          selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${
-            oc.git.repository
-          },github-owner=${oc.git.owner}`,
+      oc.raw("delete", ["all"], {
+        selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`,
+        wait: "true",
+        namespace: phase.namespace,
+      });
+      oc.raw(
+        "delete",
+        ["pvc,Secret,configmap,endpoints,RoleBinding,role,ServiceAccount,Endpoints"],
+        {
+          selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${oc.git.repository},github-owner=${oc.git.owner}`,
           wait: "true",
           namespace: phase.namespace,
-        });
-        oc.raw(
-          "delete",
-          ["pvc,Secret,configmap,endpoints,RoleBinding,role,ServiceAccount,Endpoints"],
-          {
-            selector: `app=${phase.instance},env-id=${phase.changeId},!shared,github-repo=${
-              oc.git.repository
-            },github-owner=${oc.git.owner}`,
-            wait: "true",
-            namespace: phase.namespace,
-          },
-        );
-      }
+        },
+      );
     }
-  }
+  });
 };


### PR DESCRIPTION
Added functionality to automatically clean PR deployments using the existing `clean.js` script in the `pipeline-cli`.

Use the `config.js` to set `transient: true` on environments to be automatically cleaned.