### PR TITLE
Rename  package to  'generator-bcdk'

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx yo bcdk:python-hello
 ### setup
 
 ```sh
-npm install @bcgov/generator-bcdk
+npm install @bcgov/generator-bcdk@latest
 ```
 
 If the above command gives you an error on Windows OS, you can manually link it using these commands.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npx yo bcdk:python-hello
 ### setup
 
 ```sh
-npm install @bcgov/bcdk@latest
+npm install @bcgov/generator-bcdk
 ```
 
 If the above command gives you an error on Windows OS, you can manually link it using these commands.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bcgov/bcdk",
+  "name": "@bcgov/generator-bcdk",
   "version": "0.0.3-0",
   "description": "BCGOV Developer Kit",
   "homepage": "https://developer.gov.bc.ca",


### PR DESCRIPTION
Fix for issue #67 
The current version of the @bcgov/bcdk package does not work (it isn't discoverable by `npx yo --bcdk generators`) because it doesn't follow `yeoman` naming conventions. The package name now changed to @bcgov/generator-bcdk.

Will have to publish a new npm package after merging code to release branch