### PR TITLE
Updating bcdk from v 0.0.3 to v 0.0.3-1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/bcdk",
-  "version": "0.0.2-0",
+  "version": "0.0.3-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcgov/generator-bcdk",
-  "version": "0.0.3-0",
+  "version": "0.0.3-1",
   "description": "BCGOV Developer Kit",
   "homepage": "https://developer.gov.bc.ca",
   "author": {


### PR DESCRIPTION
Updates the bcgov/bcdk package to v 0.0.3-1.

Fixes the yeoman package naming convention issue.
Package now called  @bcgov/generator-bcdk

Can be installed with `npm install @bcgov/generator-bcdk@latest`