### PR TITLE
Fix an issue where jenkins won't deploy because of invalid pvc config

### DIFF
--- a/generators/jenkins/templates/.jenkins/openshift/deploy-master.yaml
+++ b/generators/jenkins/templates/.jenkins/openshift/deploy-master.yaml
@@ -40,13 +40,11 @@ objects:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
-    annotations:
-      volume.beta.kubernetes.io/storage-class: gluster-file
-      volume.beta.kubernetes.io/storage-provisioner: kubernetes.io/glusterfs
     name: ${NAME}${SUFFIX}
   spec:
     accessModes:
     - ReadWriteOnce
+    storageClassName: netapp-file-standard
     resources:
       requests:
         storage: 1Gi

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@bcgov/bcdk",
-  "version": "0.0.3-1",
+  "name": "@bcgov/generator-bcdk",
+  "version": "0.0.3-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Since the cluster has moved to netapp for storage provisioning, gluster provisioning has been disabled. This pr addresses the dc.yaml file which was trying to provision gluster. 

Fixes #63 