### PR TITLE
Update NPM CI workflow to use different node versions (8,  10, 12)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   },
   "plugins": ["prettier"],
   "rules": {
+    "no-console": "error",
     "no-unused-vars": ["error"],
     "prettier/prettier": ["error"],
     "linebreak-style": ["warn", "unix"],

--- a/.github/workflows/npmci.yml
+++ b/.github/workflows/npmci.yml
@@ -1,8 +1,6 @@
 name: Node.js Package
 
-on:
-  release:
-    types: [created]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/npmci.yml
+++ b/.github/workflows/npmci.yml
@@ -6,12 +6,20 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - run: npm ci
-      - run: npm test
 
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [8.x,  10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install
+    - run: npm test
+      env:
+        CI: true

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,5 +1,5 @@
 {
-  "generator-bcdk": {
+  "@bcgov/generator-bcdk": {
     "promptValues": {
       "environments": "build dev test prod"
     }

--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,7 +1,0 @@
-{
-  "@bcgov/generator-bcdk": {
-    "promptValues": {
-      "environments": "build dev test prod"
-    }
-  }
-}

--- a/__mocks__/fs.js
+++ b/__mocks__/fs.js
@@ -1,0 +1,36 @@
+const path = require("path");
+
+const fs = jest.genMockFromModule("fs");
+
+// This is a custom function that our tests can use during setup to specify
+// what the files on the "mock" filesystem should look like when any of the
+// `fs` APIs are used.
+let mockFiles = Object.create(null);
+function __setMockFiles(newMockFiles) {
+  mockFiles = Object.create(null);
+  for (const file in newMockFiles) {
+    const dir = path.dirname(file);
+
+    if (!mockFiles[dir]) {
+      mockFiles[dir] = [];
+    }
+    mockFiles[dir].push(path.basename(file));
+  }
+}
+
+// A custom version of `readdirSync` that reads from the special mocked out
+// file list set via __setMockFiles
+function readdirSync(directoryPath) {
+  return mockFiles[directoryPath] || [];
+}
+
+function existsSync(file) {
+  const dir = path.dirname(file);
+  return mockFiles[dir] || [];
+}
+
+fs.__setMockFiles = __setMockFiles;
+fs.existsSync = existsSync;
+fs.readdirSync = readdirSync;
+
+module.exports = fs;

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -2,16 +2,14 @@
 const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
-
+jest.useFakeTimers();
 describe("generator-bcdk:app", () => {
-  beforeAll(() => {
-    const ctx = helpers
-      .run(path.join(__dirname, "../generators/app"))
-      .withPrompts({ someAnswer: true });
-    return ctx;
-  });
-
   it("creates files", () => {
-    assert.file(["dummyfile.txt"]);
+    helpers
+      .run(path.join(__dirname, "../generators/app"))
+      .withPrompts({ someAnswer: true })
+      .then(() => {
+        assert.file(["dummyfile.txt"]);
+      });
   });
 });

--- a/__tests__/jenkins-job.js
+++ b/__tests__/jenkins-job.js
@@ -2,15 +2,19 @@
 const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
+jest.mock("fs");
 
 describe("generator-bcdk:jenkins-job", () => {
-  beforeAll(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/jenkins-job"))
-      .withPrompts({ someAnswer: true });
+  beforeEach(() => {
+    require("fs").__setMockFiles([".git/objects/foo.txt"]);
   });
 
-  it("creates files", () => {
-    assert.file(["dummyfile.txt"]);
+  it("creates files", async () => {
+    helpers
+      .run(path.join(__dirname, "../generators/jenkins-job"))
+      .withPrompts({ someAnswer: true })
+      .then(() => {
+        assert.file(["dummyfile.txt"]);
+      });
   });
 });

--- a/__tests__/jenkins-job.js
+++ b/__tests__/jenkins-job.js
@@ -3,7 +3,7 @@ const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 jest.mock("fs");
-
+jest.useFakeTimers();
 describe("generator-bcdk:jenkins-job", () => {
   beforeEach(() => {
     require("fs").__setMockFiles([".git/objects/foo.txt"]);

--- a/__tests__/jenkins-overwrites.js
+++ b/__tests__/jenkins-overwrites.js
@@ -3,14 +3,19 @@ const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
+jest.mock("fs");
+
 describe("generator-bcdk:jenkins-overwrites", () => {
-  beforeAll(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/jenkins-overwrites"))
-      .withPrompts({ someAnswer: true });
+  beforeEach(() => {
+    require("fs").__setMockFiles([".git/objects/foo.txt"]);
   });
 
   it("creates files", () => {
-    assert.file(["dummyfile.txt"]);
+    helpers
+      .run(path.join(__dirname, "../generators/jenkins-overwrites"))
+      .withPrompts({ someAnswer: true })
+      .then(() => {
+        assert.file(["dummyfile.txt"]);
+      });
   });
 });

--- a/__tests__/jenkins-overwrites.js
+++ b/__tests__/jenkins-overwrites.js
@@ -4,6 +4,7 @@ const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
 jest.mock("fs");
+jest.useFakeTimers();
 
 describe("generator-bcdk:jenkins-overwrites", () => {
   beforeEach(() => {

--- a/__tests__/jenkins.js
+++ b/__tests__/jenkins.js
@@ -3,14 +3,19 @@ const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
+jest.mock("fs");
+
 describe("generator-bcdk:jenkins", () => {
-  beforeAll(() => {
-    return helpers
-      .run(path.join(__dirname, "../generators/jenkins"))
-      .withPrompts({ someAnswer: true });
+  beforeEach(() => {
+    require("fs").__setMockFiles([".git/objects/foo.txt"]);
   });
 
   it("creates files", () => {
-    assert.file(["dummyfile.txt"]);
+    helpers
+      .run(path.join(__dirname, "../generators/jenkins"))
+      .withPrompts({ someAnswer: true })
+      .then(() => {
+        assert.file(["dummyfile.txt"]);
+      });
   });
 });

--- a/__tests__/jenkins.js
+++ b/__tests__/jenkins.js
@@ -4,7 +4,7 @@ const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
 jest.mock("fs");
-
+jest.useFakeTimers();
 describe("generator-bcdk:jenkins", () => {
   beforeEach(() => {
     require("fs").__setMockFiles([".git/objects/foo.txt"]);

--- a/__tests__/pipeline.js
+++ b/__tests__/pipeline.js
@@ -4,10 +4,8 @@ const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
 describe("generator-bcdk:pipeline", () => {
-  beforeAll(() => {});
-
   it("main at root", () => {
-    return helpers
+    helpers
       .run(path.join(__dirname, "../generators/pipeline"))
       .withPrompts({ name: "main" })
       .then(() => {
@@ -28,7 +26,7 @@ describe("generator-bcdk:pipeline", () => {
   });
 
   it("main at subfolder", () => {
-    return helpers
+    helpers
       .run(path.join(__dirname, "../generators/pipeline"))
       .withPrompts({ name: "hello", path: "hello" })
       .then(() => {

--- a/__tests__/pipeline.js
+++ b/__tests__/pipeline.js
@@ -2,6 +2,7 @@
 const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
+jest.useFakeTimers();
 
 describe("generator-bcdk:pipeline", () => {
   it("main at root", () => {

--- a/__tests__/python-hello.js
+++ b/__tests__/python-hello.js
@@ -5,13 +5,14 @@ const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
 
 describe("generator-bcdk:python-hello", () => {
-  beforeAll(() => {
-    return helpers.run(path.join(__dirname, "../generators/python-hello")).withPrompts({
-      someAnswer: true,
-    });
-  });
-
   it("creates files", () => {
-    assert.file(["hello-main/requirements.txt", "hello-base/requirements.txt"]);
+    helpers
+      .run(path.join(__dirname, "../generators/python-hello"))
+      .withPrompts({
+        someAnswer: true,
+      })
+      .then(() => {
+        assert.file(["hello-main/requirements.txt", "hello-base/requirements.txt"]);
+      });
   });
 });

--- a/__tests__/python-hello.js
+++ b/__tests__/python-hello.js
@@ -3,7 +3,7 @@
 const path = require("path");
 const assert = require("yeoman-assert");
 const helpers = require("yeoman-test");
-
+jest.useFakeTimers();
 describe("generator-bcdk:python-hello", () => {
   it("creates files", () => {
     helpers


### PR DESCRIPTION
Fixes #66 

I was unable to find incompatibility issues running `nvm` locally. To ensure that this isn't an issue I have updated the __Github Action CI workflow__ to include runs on node 8,10,12